### PR TITLE
Validointi

### DIFF
--- a/Lukuvinkisto/src/main/java/Lukuvinkisto/dao/TietokantaDAO.java
+++ b/Lukuvinkisto/src/main/java/Lukuvinkisto/dao/TietokantaDAO.java
@@ -109,12 +109,12 @@ public class TietokantaDAO {
      * @param title kirjan nimi
      * @return true: kirjan poisto onnistui false: kirjan poisto epäonnisti
      */
-    public boolean removeBook(Book book) {
+    public boolean removeBook(String title, String author) {
         try {
             Connection dM = createConnection();
             PreparedStatement p1 = dM.prepareStatement("DELETE FROM Books WHERE title=? AND author=?");
-            p1.setString(1, book.getTitle());
-            p1.setString(2, book.getAuthor());
+            p1.setString(1, title);
+            p1.setString(2, author);
             int r = p1.executeUpdate();
             dM.close();
             if (r==1) {
@@ -189,11 +189,11 @@ public class TietokantaDAO {
         }
     }    
     
-    public boolean removeVideo(Video video) {
+    public boolean removeVideo(String title) {
         try {
             Connection dM = createConnection();
             PreparedStatement p1 = dM.prepareStatement("DELETE FROM Videos WHERE title=?");
-            p1.setString(1, video.getTitle());
+            p1.setString(1, title);
             int r = p1.executeUpdate();
             dM.close();
             if (r==1) {
@@ -251,11 +251,11 @@ public class TietokantaDAO {
         }
     }    
     
-    public boolean removeArticle(Article article) {
+    public boolean removeArticle(String title) {
         try {
             Connection dM = createConnection();
             PreparedStatement p1 = dM.prepareStatement("DELETE FROM Articles WHERE title=?");
-            p1.setString(1, article.getTitle());
+            p1.setString(1, title);
             int r = p1.executeUpdate();
             dM.close();
             if (r==1) {

--- a/Lukuvinkisto/src/main/java/Lukuvinkisto/media/Book.java
+++ b/Lukuvinkisto/src/main/java/Lukuvinkisto/media/Book.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 public class Book extends Media {
 
+    private int pages;
     public Book(String title, String author, int pages, List<String> tags) {
         super(title, author, "", pages, tags);
+        this.pages = pages;
     }
 
     @Override
@@ -15,4 +17,9 @@ public class Book extends Media {
         }
         return author + " : "  + title + ", sivumäärä: " + length + ", Tagit: " + this.getTagString();
     }
+    
+    public int getPages() {
+        return pages;
+    }
+   
 }

--- a/Lukuvinkisto/src/main/java/Lukuvinkisto/netio/NArticleIO.java
+++ b/Lukuvinkisto/src/main/java/Lukuvinkisto/netio/NArticleIO.java
@@ -30,11 +30,18 @@ public class NArticleIO {
         return works;
     }
 
-    public boolean remove(Article article) {
-        return db.removeArticle(article);
+    public boolean remove(String title) {
+        return db.removeArticle(title);
     }
 
-    public boolean add(Article article) {
-        return db.addArticle(article.getTitle(), article.getLink(), article.getTags());
+    public boolean add(String title, String link, List<String> tags) {
+        if (this.validate(title, link)) {
+            return db.addArticle(title, link, tags);
+        }
+        return false;
+    }
+    
+    private boolean validate(String title, String link) {
+        return title.length() > 2 && link.length() > 2;
     }
 }

--- a/Lukuvinkisto/src/main/java/Lukuvinkisto/netio/NBookIO.java
+++ b/Lukuvinkisto/src/main/java/Lukuvinkisto/netio/NBookIO.java
@@ -10,6 +10,7 @@ import Lukuvinkisto.media.Book;
 import Lukuvinkisto.media.Media;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
 
 /**
  *
@@ -43,12 +44,22 @@ public class NBookIO {
         return works;
     }
 
-    public boolean remove(Book book) {
-        return db.removeBook(book);
+    public boolean remove(String title, String author) { 
+        return db.removeBook(title, author);
     }
     
-    public boolean add(Book book){
-        return db.addBook(book.getTitle(), book.getAuthor(), String.valueOf(book.getLength()), book.getTags());
+    public boolean add(String title, String Author, String pages, List<String> tags){
+        if (this.validate(title, Author, pages)) {
+            return db.addBook(title, Author, pages, tags);
+           
+        }
+        return false;
     }
     
+    private boolean validate(String title, String author, String pages) {
+        if (!StringUtils.isNumeric(pages)) {
+            return false;
+        }
+        return author.length() > 2 && Integer.valueOf(pages) > 0 && title.length()>0;
+    }
 }

--- a/Lukuvinkisto/src/main/java/Lukuvinkisto/netio/NVideoIO.java
+++ b/Lukuvinkisto/src/main/java/Lukuvinkisto/netio/NVideoIO.java
@@ -30,11 +30,18 @@ public class NVideoIO {
         return works;
     }
 
-    public boolean remove(Video video) {
-        return db.removeVideo(video);
+    public boolean remove(String title) {
+        return db.removeVideo(title);
     }
 
-    public boolean add(Video video) {
-        return db.addVideo(video.getTitle(), video.getLink(), video.getTags());
+    public boolean add(String title, String link, List<String> tags) {
+        if (this.validate(title, link)) {
+            return db.addVideo(title, link, tags);
+        }
+        return false;
+    }
+    
+    private boolean validate(String title, String link) {
+        return title.length() > 2 && link.length() > 2;
     }
 }

--- a/Lukuvinkisto/src/main/java/Main/Main.java
+++ b/Lukuvinkisto/src/main/java/Main/Main.java
@@ -89,7 +89,7 @@ public class Main {
             String title = request.queryParams("otsikko");
             String link = request.queryParams("verkkoosoite");
 
-            Boolean articleAdded = articleNIO.add(new Article(title, link, null));
+            Boolean articleAdded = articleNIO.add(title, link, null);
 
             if (!articleAdded) {
                 model.put("error", "Artikkelia ei saatu lisättyä");
@@ -107,7 +107,7 @@ public class Main {
             String title = request.queryParams("otsikko");
             String link = request.queryParams("verkkoosoite");
 
-            Boolean bookRemoved = articleNIO.remove(new Article(title, link, null));
+            Boolean bookRemoved = articleNIO.remove(title);
 
             if (!bookRemoved) {
                 model.put("error", "Artikkelia ei saatu poistettua");
@@ -146,10 +146,10 @@ public class Main {
             String title = request.queryParams("otsikko");
             String link = request.queryParams("verkkoosoite");
 
-            Boolean videoAdded = videoNIO.add(new Video(title, link, null));
+            Boolean videoAdded = videoNIO.add(title, link, null);
 
             if (!videoAdded) {
-                model.put("error", "Videoa ei saatu lisättyä");
+                model.put("error", "Videota ei saatu lisättyä");
                 model.put("template", "templates/lisaavideo.html");
                 return new ModelAndView(model, LAYOUT);
             }
@@ -164,7 +164,7 @@ public class Main {
             String title = request.queryParams("otsikko");
             String link = request.queryParams("verkkoosoite");
 
-            Boolean videoRemoved = videoNIO.remove(new Video(title, link, null));
+            Boolean videoRemoved = videoNIO.remove(title);
 
             if (!videoRemoved) {
                 model.put("error", "Videota ei saatu poistettua");
@@ -201,9 +201,9 @@ public class Main {
             HashMap<String, String> model = new HashMap<>();
             String title = request.queryParams("otsikko");
             String author = request.queryParams("kirjoittaja");
-            int pages = Integer.valueOf(request.queryParams("sivumaara"));
+            String pages = request.queryParams("sivumaara");
 
-            Boolean bookAdded = bookNIO.add(new Book(title, author, pages, null));
+            Boolean bookAdded = bookNIO.add(title, author, pages, null);
 
             if (!bookAdded) {
                 model.put("error", "Kirjaa ei saatu lisättyä");
@@ -221,7 +221,7 @@ public class Main {
             String title = request.queryParams("otsikko");
             String author = request.queryParams("kirjoittaja");
 
-            Boolean bookRemoved = bookNIO.remove(new Book(title, author, 0, null));
+            Boolean bookRemoved = bookNIO.remove(title, author);
 
             if (!bookRemoved) {
                 model.put("error", "Kirjaa ei saatu poistettua");
@@ -258,7 +258,7 @@ public class Main {
         siteAddresses.put("index", "templates/index.html");
         
         siteAddresses.put("lisaakirja", "templates/lisaakirja.html");
-        siteAddresses.put("lisaaartikkeli", "templates/lisaaartikkeli.html");
+        siteAddresses.put("lisaaArtikkeli", "templates/lisaaArtikkeli.html");
         siteAddresses.put("lisaavideo", "templates/lisaavideo.html");
         siteAddresses.put("lisaavinkki", "templates/lisaavinkki.html");
         

--- a/Lukuvinkisto/src/test/java/Lukuvinkisto/ArticleDaoTest.java
+++ b/Lukuvinkisto/src/test/java/Lukuvinkisto/ArticleDaoTest.java
@@ -60,7 +60,7 @@ public class ArticleDaoTest {
     @Test
     public void testRemovingNonExistingArticleReturnsFalse() {
         db.addArticle(article1.getTitle(), article1.getLink(), article1.getTags());
-        boolean r = db.removeArticle(article2);
+        boolean r = db.removeArticle(article2.getTitle());
         assertFalse(r);
     } 
 
@@ -76,7 +76,7 @@ public class ArticleDaoTest {
     public void testTwoArticlesAddedOneRemoved() {
         db.addArticle(article1.getTitle(), article1.getLink(), article1.getTags());
         db.addArticle(article2.getTitle(), article2.getLink(), article2.getTags());
-        db.removeArticle(article1);
+        db.removeArticle(article1.getTitle());
         
         List<Media> list = db.listArticles(null);
         assertEquals(list.size(),1);

--- a/Lukuvinkisto/src/test/java/Lukuvinkisto/Stepdefs.java
+++ b/Lukuvinkisto/src/test/java/Lukuvinkisto/Stepdefs.java
@@ -1,6 +1,9 @@
 package Lukuvinkisto;
 
-import Lukuvinkisto.media.Book;
+import Lukuvinkisto.dao.TiedostoDAO;
+import Lukuvinkisto.dao.TietokantaDAO;
+import Lukuvinkisto.media.*;
+import Lukuvinkisto.netio.*;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
@@ -10,43 +13,50 @@ import java.util.Queue;
 import static org.junit.Assert.*;
 
 public class Stepdefs {
+
     Book book;
+    Video video;
+    Article article;
     Queue<String> inputs;
-        
-//    @Before
-//    public void setup() {
-//        inputs = new ArrayDeque();
-//        inputIO = new InputIO(new MediaStub(), new InputStub(inputs));
-//    }
-    
+    TiedostoDAO db;
+    Integer a;
+    TietokantaDAO instance;
+    NArticleIO nArticle;
+    NBookIO nBook;
+    NVideoIO nVideo;
+    boolean validateResult;
+
+    @Before
+    public void initialize() {
+        db = new TiedostoDAO();
+        a = db.createFile("TestDatabase");
+        instance = new TietokantaDAO("TestDatabase");
+
+        nArticle = new NArticleIO(instance);
+        nBook = new NBookIO(instance);
+        nVideo = new NVideoIO(instance);
+    }
+
     @Given("Book is initialized with title {string} and author {string} and page count {int}")
     public void bookIsInitialized(String title, String author, int pagecount) {
         book = new Book(title, author, pagecount, null);
     }
-//    
-//    @Given("{String} is inputted")
-//    public void firstInput(String val) {
-//        inputs = new ArrayDeque();
-//        inputIO = new InputIO(new MediaStub(), new InputStub(inputs));
-//        inputs.add(val);
-//    }
-//    @When("book with name of {String}, author of {String} and {int} pages is added")
-//    public void bookInputted(String name, String author, int pages){
-//        inputs.add(name);
-//        inputs.add(author);
-//        inputs.add(pages + "");
-//    }
-//    @When("{String} is inputted next")
-//    public void thenInputted(String val){
-//        inputs.add(val);
-//    }
-//    
-    
+
+    @Given("Video is initialized with title {string} and link {string}")
+    public void videoIsInitialized(String title, String link) {
+        video = new Video(title, link, null);
+    }
+
+    @Given("Article is initialized with title {string} and link {string}")
+    public void articleIsInitialized(String title, String link) {
+        article = new Article(title, link, null);
+    }
+
     @Then("the author should be {string}")
     public void theAuthorShouldBe(String val) {
         assertEquals(val, book.getAuthor());
     }
-    
+
     @Then("the title should be {string}")
     public void theTitleShouldBe(String val) {
         assertEquals(val, book.getTitle());
@@ -56,13 +66,19 @@ public class Stepdefs {
     public void thePagecountShouldBe(int val) {
         assertEquals(val, book.getLength());
     }
-    
 
-//    @Then("the system prints out {String}")
-//    public void checkPrint(String val){
-//        assertEquals(val, ((InputStub)inputIO.getInputIO()).getLastPrint());
-//    }
-//    
+    @Then("Book add validation is {string}")
+    public void bookValidationReturns(String trueFalse) {
+        assertEquals(trueFalse, String.valueOf(nBook.add(book.getTitle(), book.getAuthor(), String.valueOf(book.getPages()), null)));
+    }
 
+    @Then("Video add validation is {string}")
+    public void videoAddValidationReturns(String trueFalse) {
+        assertEquals(trueFalse, String.valueOf(nVideo.add(video.getTitle(), video.getLink(), null)));
+    }
     
+    @Then("Article add validation is {string}")
+    public void articleAddValidationReturns(String trueFalse) {
+        assertEquals(trueFalse, String.valueOf(nArticle.add(article.getTitle(), article.getLink(), null)));
+    }
 }

--- a/Lukuvinkisto/src/test/java/Lukuvinkisto/VideoDaoTest.java
+++ b/Lukuvinkisto/src/test/java/Lukuvinkisto/VideoDaoTest.java
@@ -60,7 +60,7 @@ public class VideoDaoTest {
     @Test
     public void testRemovingNonExistingVideoReturnsFalse() {
         db.addVideo(video1.getTitle(), video1.getLink(), video1.getTags());
-        boolean r = db.removeVideo(video2);
+        boolean r = db.removeVideo(video2.getTitle());
         assertFalse(r);
     } 
 
@@ -76,7 +76,7 @@ public class VideoDaoTest {
     public void testTwoVideosAddedOneRemoved() {
         db.addVideo(video1.getTitle(), video1.getLink(), video1.getTags());
         db.addVideo(video2.getTitle(), video2.getLink(), video2.getTags());
-        db.removeVideo(video1);
+        db.removeVideo(video1.getTitle());
         
         List<Media> list = db.listVideos(null);
         assertEquals(list.size(),1);

--- a/Lukuvinkisto/src/test/java/Lukuvinkisto/dao/TietokantaDAOTest.java
+++ b/Lukuvinkisto/src/test/java/Lukuvinkisto/dao/TietokantaDAOTest.java
@@ -84,7 +84,7 @@ public class TietokantaDAOTest {
     @Test
     public void testRemoveBook() {
         Book book = new Book("Ulysses", "James Joyce", 409, null);
-        boolean result2 = instance.removeBook(book);
+        boolean result2 = instance.removeBook(book.getTitle(), book.getAuthor());
         assertEquals(true, result2);
         
         String searchTerm = null;
@@ -101,7 +101,7 @@ public class TietokantaDAOTest {
         
         // Removing a non-exisgent book
         Book book = new Book("Ulysses and Donald Duck", "James Joyce", 409, null);
-        boolean result2 = instance.removeBook(book);
+        boolean result2 = instance.removeBook(book.getTitle(), book.getAuthor());
         assertEquals(false, result2);
         
         // Checking the list size afterwards

--- a/Lukuvinkisto/src/test/resources/Lukuvinkisto/bookCreation.feature
+++ b/Lukuvinkisto/src/test/resources/Lukuvinkisto/bookCreation.feature
@@ -1,6 +1,6 @@
 Feature: As a user I want to add a book
 
-    Scenario: Book is intialized correctly
+    Scenario: Book is initialized correctly
         Given Book is initialized with title "Testi" and author "Testinen" and page count 77
         Then the title should be "Testi"
         And  the author should be "Testinen"

--- a/Lukuvinkisto/src/test/resources/Lukuvinkisto/inputValidation.feature
+++ b/Lukuvinkisto/src/test/resources/Lukuvinkisto/inputValidation.feature
@@ -1,0 +1,46 @@
+Feature: As a user I want my book input to be validated
+
+    Scenario: Book input is correct
+        Given Book is initialized with title "Testi" and author "Testinen" and page count 77
+        Then  Book add validation is "true"
+        
+    Scenario: Title is too short
+        Given Book is initialized with title "" and author "Testinen" and page count 77
+        Then  Book add validation is "false"
+        
+    Scenario: Author name is too short
+        Given Book is initialized with title "Testi" and author "" and page count 77
+        Then  Book add validation is "false"
+        
+    Scenario: Page count is negative
+        Given Book is initialized with title "Testi" and author "Testinen" and page count -2
+        Then  Book add validation is "false"
+        
+    Scenario: Page count is zero
+        Given Book is initialized with title "Testi" and author "Testinen" and page count 0
+        Then  Book add validation is "false"
+        
+    Scenario: Video input is correct
+        Given Video is initialized with title "testivideo" and link "testlink"
+        Then  Video add validation is "true"
+        
+    Scenario: Video title is too short
+        Given Video is initialized with title "" and link "testlink"
+        Then  Video add validation is "false"
+        
+    Scenario: Video link is too short
+        Given Video is initialized with title "testivideo" and link ""
+        Then  Video add validation is "false"
+
+    Scenario: Article input is correct
+        Given Article is initialized with title "testarticle" and link "testlink"
+        Then  Article add validation is "true"
+        
+    Scenario: Article title is too short
+        Given Article is initialized with title "" and link "testlink"
+        Then  Article add validation is "false"
+        
+    Scenario: Article link is too short
+        Given Article is initialized with title "testarticle" and link ""
+        Then  Article add validation is "false"
+        


### PR DESCRIPTION
Syötteen validointiominaisuus. Muutettu olioviitteet muuttujaviitteiksi, koska olioita käytettiin vain lokeroina muuttujille eikä niillä mielestäni ollut poistetuissa kohdissa mitään järkevää roolia.